### PR TITLE
Update build for newer NixPkg and newer Pandoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,28 @@
 PANDOC = pandoc
-IFORMAT = markdown
 FLAGS = --standalone --toc --toc-depth=2 --highlight-style pygments
 TEMPLATE = page.tmpl
 STYLE = css/style.css
+SRC = tutorial
 
-HTML = tutorial.html
-
-all: $(HTML)
+all: $(SRC).html $(SRC).epub $(SRC).pdf
 
 includes: includes.hs
 	ghc --make $<
 
 %.html: %.md includes
-	./includes < $< | $(PANDOC) -c $(STYLE) --template $(TEMPLATE) -s -f $(IFORMAT) -t html $(FLAGS) -o $@
+	$(PANDOC) -f markdown -t json < $< \
+	| ./includes \
+	| pandoc -f json -t html --template $(TEMPLATE) -c $(STYLE) $(FLAGS) -o $@
 
 %.epub: %.md includes
-	./includes < $< | $(PANDOC) -f $(IFORMAT) -t epub $(FLAGS) -o $@
+	$(PANDOC) -f markdown -t json < $< \
+	| ./includes \
+	| pandoc -f json -t epub --template $(TEMPLATE) -c $(STYLE) $(FLAGS) -o $@
 
 %.pdf: %.md includes
-	./includes < $< | $(PANDOC) -c -s -f $(IFORMAT) --latex-engine=xelatex $(FLAGS) -o $@
+	$(PANDOC) -f markdown -t json < $< \
+	| ./includes \
+	| pandoc -f json -t latex --latex-engine=xelatex -c $(STYLE) $(FLAGS) -o $@
 
 clean:
-	-rm $(CHAPTERS) $(HTML)
+	rm -f *.html *.epub *.pdf

--- a/includes.hs
+++ b/includes.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- includes.hs
-import Text.Pandoc
+import Text.Pandoc.JSON
 
 doInclude :: Block -> IO Block
 doInclude cb@(CodeBlock (id, classes, namevals) contents) =
@@ -18,6 +18,4 @@ doHtml cb@(CodeBlock (id, classes, namevals) contents) =
 doHtml x = return x
 
 main :: IO ()
-main = getContents >>= bottomUpM doInclude . readMarkdown def
-                   >>= bottomUpM doHtml
-                   >>= putStrLn . writeMarkdown def
+main = toJSONFilter (\b -> doInclude b >>= doHtml)

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,9 @@
 with (import <nixpkgs> { });
 
 let
-  ghc = haskellngPackages;
-
-  withHoogle = haskellEnv:
-    ghc.callPackage <nixpkgs/pkgs/development/libraries/haskell/hoogle/local.nix> {
-      packages = haskellEnv.paths;
-    };
-
-  ghcPackages = ghc.ghcWithPackages (p: with p; [
-    pandoc
+  ghcPackages = haskellPackages.ghcWithHoogle
+    (haskellPackages: with haskellPackages; [
+      pandoc
   ]);
 
 in
@@ -19,7 +13,6 @@ with pkgs;
 runCommand "dummy" {
   buildInputs = [
     ghcPackages
-    (withHoogle ghcPackages)
   ];
   shellHook = ''
     export NIX_GHC="${ghcPackages}/bin/ghc"

--- a/tutorial.md
+++ b/tutorial.md
@@ -444,7 +444,6 @@ scenarios. Pretty slick, huh?
 [modularity]: http://nixos.org/nixos/manual/sec-configuration-syntax.html#sec-modularity
 [builtins]: http://nixos.org/nix/manual/#ssec-builtins
 [pkgs.lib]: https://github.com/NixOS/nixpkgs/blob/master/lib/default.nix
-[pkgs.lib]: https://github.com/NixOS/nixpkgs/blob/master/lib/default.nix
 [environment.systemPackages]: http://nixos.org/nixos/manual/ch-options.html#opt-environment.systemPackages
 [nix-shell]: http://nixos.org/nix/manual/#sec-nix-shell
 [ouroboros]: http://en.wikipedia.org/wiki/Ouroboros


### PR DESCRIPTION
* Update to use the haskellPackages as they're currently structured
* Update Pandoc to fix backwards-incompatible changes in newer version
* Remove duplicate link error

I noticed #1, and figured I have NixOS so I'll just build it, but it hasn't
worked since the haskellngPackages became the haskellPackages and ghcWithHoogle
came out, so I fixed #2, which also involved fixing some issues with Pandoc.

I don't know what the original output looked like, but this one still has the
TOC in the sidebar and has nice colored highlighting on code blocks, so I assume
the formatting is working with the new pandoc.